### PR TITLE
Reduce allocations in infer_selector_key

### DIFF
--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -21,16 +21,16 @@ module Primer
 
       # Replacements for some classnames that end up being a different argument key
       REPLACEMENT_KEYS = {
-        "^anim" => "animation",
-        "^v-align" => "vertical_align",
-        "^d" => "display",
-        "^wb" => "word_break",
-        "^v" => "visibility",
-        "^width" => "w",
-        "^height" => "h",
-        "^color-bg" => "bg",
-        "^color-border" => "border_color",
-        "^color-fg" => "color"
+        /^anim/ => :animation,
+        /^v-align/ => :vertical_align,
+        /^d/ => :display,
+        /^wb/ => :word_break,
+        /^v/ => :visibility,
+        /^width/ => :w,
+        /^height/ => :h,
+        /^color-bg/ => :bg,
+        /^color-border/ => :border_color,
+        /^color-fg/ => :color
       }.freeze
 
       SUPPORTED_KEY_CACHE = Hash.new { |h, k| h[k] = !UTILITIES[k].nil? }
@@ -193,8 +193,8 @@ module Primer
         end
 
         def infer_selector_key(selector)
-          REPLACEMENT_KEYS.each do |k, v|
-            return v.to_sym if selector.match?(Regexp.new(k))
+          REPLACEMENT_KEYS.each do |pattern, replacement|
+            return replacement if selector.match?(pattern)
           end
           selector.split("-").first.to_sym
         end

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -68,7 +68,7 @@ namespace :utilities do
 
       # Look for a replacement key
       Primer::Classify::Utilities::REPLACEMENT_KEYS.each do |k, v|
-        next unless classname.match?(Regexp.new(k))
+        next unless classname.match?(k)
 
         key = v
         classname.sub!(Regexp.new("#{k}-"), "")


### PR DESCRIPTION
This method allocates unnecessarily in a hot loop.  Instead of building
new Regexp objects for each match, just store the keys as regexps.